### PR TITLE
Adding extensions.json for vscode recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+      "ms-vscode.vscode-csharp",
+      "formulahendry.dotnet-test-explorer",
+      "ms-vscode.vscode-node-azure-pack",
+      "ms-kubernetes-tools.vscode-kubernetes-tools",
+      "redhat.vscode-yaml"
+    ]
+}


### PR DESCRIPTION
This adds recommendations file so that when someone clones the repo and uses VSCode it will ensure it recommends the ideal extensions.